### PR TITLE
Ajuste no arredondamento e exibicao dos valores

### DIFF
--- a/controlefinanceiromotorista/lib/telaLancamento.dart
+++ b/controlefinanceiromotorista/lib/telaLancamento.dart
@@ -54,6 +54,7 @@ class _TelaLancamentoState extends State<TelaLancamento> {
     if (widget.lancamento != null){      
       _lancamento = Lancamento.from(widget.lancamento.toMap());       
       _valueDropDownEntradaSaida = _lancamento.entrada == 1 ? 'Entrada' : 'Saída';
+      _corValor = _lancamento.entrada == 1 ? Colors.green : Colors.red;
       _valorController.text = _lancamento.valor.toString();
       _descricaoController.text = _lancamento.descricao;
       _dataController.text = _formatoData.format(_lancamento.data);
@@ -184,7 +185,7 @@ class _TelaLancamentoState extends State<TelaLancamento> {
       keyboardType: TextInputType.numberWithOptions(decimal:true),
       onChanged: (text){
         setState((){
-          _lancamento.valor = double.tryParse(text);
+          _lancamento.valor = double.tryParse(text).abs();
         });
       },
     );

--- a/controlefinanceiromotorista/lib/telaPrincipal.dart
+++ b/controlefinanceiromotorista/lib/telaPrincipal.dart
@@ -168,19 +168,22 @@ class _telaPrincipalState extends State<telaPrincipal> {
                   ],
                 ),
               ),
-              Container(
-                padding: EdgeInsets.only(left: 100),
-                alignment: Alignment.center,
-                child: Text(
-                  'R\$ ' + _lancamentos[index].valor.toString(),
-                  style: TextStyle(
-                        fontSize: 30.0,
-                        color: _lancamentos[index].entrada == 1 ? 
-                          Colors.green : 
-                          Colors.red
-                      ),
-                ),
+              Flexible(child: 
+                Container(
+                  padding: EdgeInsets.only(left: 80),                                  
+                  child: Text(
+                    'R\$ ' + _lancamentos[index].valor.toStringAsFixed(2),
+                    overflow: TextOverflow.fade,                  
+                    style: TextStyle(
+                          fontSize: 30.0,                          
+                          color: _lancamentos[index].entrada == 1 ? 
+                            Colors.green : 
+                            Colors.red
+                        ),
+                  ),
+                )
               )
+              
             ],
           ),
         )         
@@ -191,7 +194,7 @@ class _telaPrincipalState extends State<telaPrincipal> {
   void _updateAppBarTitle(bool visible){
     setState(() {
       if(visible){
-      _appBarTitle = 'Saldo do período: R\$ $_somaLancamentos';
+      _appBarTitle = 'Saldo do período: R\$ ' + _somaLancamentos.toStringAsFixed(2);
     }
     else{
       _appBarTitle = 'Tela Principal';
@@ -258,7 +261,9 @@ class _telaPrincipalState extends State<telaPrincipal> {
               _updateAppBarTitle(_saldoVisible);
             })            
         ],
-        title: Text(_appBarTitle),
+        title: Text(_appBarTitle,
+          style: TextStyle(fontSize: 18.0)
+        ),
         backgroundColor: Colors.blueAccent,
         toolbarHeight: 70, // default is 56        
       ),


### PR DESCRIPTION
Ajuste no arredondamento e exibicao dos valores.
Os valores grandes estão indo para linha de baixo da lista, antes estava com erro.
Os números são exibidos até a segunda casa decimal.
Um valor negativo com o sinal de "menos" na tela de lançamentos é ignorado, é acatado apenas o campo "entrada/saída".